### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,24 +6,24 @@
 # Datatypes (KEYWORD1)
 ###########################################
 
-AERobot  KEYWORD1
+AERobot	KEYWORD1
 
 ###########################################
 # Methods and Functions (KEYWORD2)
 ###########################################
-setLED KEYWORD2
-ledControl KEYWORD2
-move_forward KEYWORD2
-move_ccw KEYWORD2
-rotate_ccw KEYWORD2
-move_cw KEYWORD2
-rotate_cw KEYWORD2
-move_backward KEYWORD2
-move_stop KEYWORD2
-move KEYWORD2
-load_calibration KEYWORD2
-initAERobot KEYWORD2
-lightSens KEYWORD2
-distSens KEYWORD2
-bumpSens KEYWORD2
-lineSens KEYWORD2
+setLED	KEYWORD2
+ledControl	KEYWORD2
+move_forward	KEYWORD2
+move_ccw	KEYWORD2
+rotate_ccw	KEYWORD2
+move_cw	KEYWORD2
+rotate_cw	KEYWORD2
+move_backward	KEYWORD2
+move_stop	KEYWORD2
+move	KEYWORD2
+load_calibration	KEYWORD2
+initAERobot	KEYWORD2
+lightSens	KEYWORD2
+distSens	KEYWORD2
+bumpSens	KEYWORD2
+lineSens	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords